### PR TITLE
0.2.39 release

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,14 @@
+v0.2.39
+New endpoints:
+    - Added support for /retry_webhook endpoint.
+Enhancements:
+    - Added SessionIdentifier new optional input field for Device object in /register.
+    - Added sessionIdentifier new optional input field for ./add register-data for add device.
+    - Added kycLevel new optional input field in /check_kyc.
+    - Added KycLevel new optional input field in /check_instant_ach.
+    - Added new processing type "INSTANT_SETTLEMENT" in ProcessingType object in /issue_sila.
+    - Added ProcessingType object new optional input fields in SearchFilters and ChildTransactions array to the Transaction response in /get_transactions.
+
 v0.2.37
 New endpoints:
     - Added support for /open_virtual_account.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,12 +2,12 @@ v0.2.39
 New endpoints:
     - Added support for /retry_webhook endpoint.
 Enhancements:
-    - Added SessionIdentifier new optional input field for Device object in /register.
-    - Added sessionIdentifier new optional input field for ./add register-data for add device.
-    - Added kycLevel new optional input field in /check_kyc.
-    - Added KycLevel new optional input field in /check_instant_ach.
-    - Added new processing type "INSTANT_SETTLEMENT" in ProcessingType object in /issue_sila.
-    - Added ProcessingType object new optional input fields in SearchFilters and ChildTransactions array to the Transaction response in /get_transactions.
+    - Added session_identifier new optional input field for Device object in /register.
+    - Added session_identifier new optional input field for ./add register-data for add device.
+    - Added kyc_level new optional input field in /check_kyc.
+    - Added kyc_level new optional input field in /check_instant_ach.
+    - Added new processing type "INSTANT_SETTLEMENT" in processing_type object in /issue_sila.
+    - Added processing_type object new optional input fields in search_filters and child_transactions array to the Transaction response in /get_transactions.   
 
 v0.2.37
 New endpoints:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='silasdk',
 
 
-    version='0.2.37',
+    version='0.2.39',
 
     description='Sila Python library for message signing and api wrapper',
 
@@ -33,7 +33,7 @@ setup(
 
     ],
 
-    keywords='Sila v0.2.37 Rest API',
+    keywords='Sila v0.2.39 Rest API',
 
     packages=find_packages(exclude=["tests", "tests.*"]),
 

--- a/silasdk/client.py
+++ b/silasdk/client.py
@@ -142,7 +142,7 @@ class App():
         appsignature = EthWallet.signMessage(msg, self.app_private_key)
         header = {
             "authsignature": appsignature,
-            "User-Agent": 'SilaSDK-python/0.2.37'
+            "User-Agent": 'SilaSDK-python/0.2.39'
         }
         if content_type is not None and content_type == 'multipart/form-data':
             pass

--- a/silasdk/processingTypes.py
+++ b/silasdk/processingTypes.py
@@ -5,4 +5,5 @@ class ProcessingTypes(str, Enum):
     STANDARD_ACH = 'STANDARD_ACH',
     SAME_DAY_ACH = 'SAME_DAY_ACH',
     INSTANT_ACH = 'INSTANT_ACH',
-    CARD = "CARD"
+    CARD = "CARD",
+    INSTANT_SETTLEMENT = "INSTANT_SETTLEMENT"

--- a/silasdk/schema.py
+++ b/silasdk/schema.py
@@ -250,7 +250,8 @@ Schema = [
             "naics_code": None
         },
         "device": {
-            "device_fingerprint": None
+            "device_fingerprint": None,
+            "session_identifier": None
         }
     }},
     {"link_business_member_msg": {
@@ -326,7 +327,8 @@ Schema = [
             "page": '',
             "per_page": '',
             "transaction_types": [],
-            "bank_account_name":None
+            "bank_account_name":None,
+            "processing_type": None,
         }
     }},
     {'cancel_transaction_msg': {
@@ -359,7 +361,8 @@ Schema = [
         "postal_code": None,
         "country": None,
         "sms_opt_in": None,
-        "device_fingerprint": None
+        "device_fingerprint": None,
+        "session_identifier": None
     }},
     {"update_registration_data_msg": {
         "header": {
@@ -521,7 +524,8 @@ Schema = [
                 "crypto": "ETH",
                 "reference": None
             },
-            "account_name": None
+            "account_name": None,
+            "kyc_level": None
         }
     },
     {
@@ -615,6 +619,20 @@ Schema = [
                 "page": None,
                 "per_page": None
             }
+        }
+    },
+    {
+        "retry_webhook": {
+            "header": {
+                "created": None,
+                "app_handle": None,
+                "user_handle": None,
+                "reference": None,
+                "version": "0.2",
+                "crypto": "ETH"
+            },
+            "message": "header_msg",
+            "event_uuid": None,
         }
     },
     {

--- a/silasdk/users.py
+++ b/silasdk/users.py
@@ -462,3 +462,11 @@ class User():
         response = message.postRequest(
             app, path, msg_type, payload, user_private_key)
         return response
+
+    @staticmethod
+    def retry_webhook(app: App, payload: dict, user_private_key: str) -> dict:
+        path = '/retry_webhook'
+        msg_type = "retry_webhook"
+        response = message.postRequest(
+            app, path, msg_type, payload, user_private_key)
+        return response

--- a/tests/test002_register.py
+++ b/tests/test002_register.py
@@ -1,7 +1,8 @@
 import unittest
 from silasdk.users import User
 from tests.test_config import (app, basic_individual_handle, business_handle, eth_address, eth_address_2,
-                               eth_address_3, eth_address_4, eth_address_5, user_handle, user_handle_2, instant_ach_handle)
+                               eth_address_3, eth_address_4, eth_address_5, user_handle, user_handle_2, 
+                               instant_ach_handle, sardine_handle, eth_address_6)
 
 
 class Test002RegisterTest(unittest.TestCase):
@@ -14,7 +15,7 @@ class Test002RegisterTest(unittest.TestCase):
             "entity_name": 'Example User',
             "identity_value": "123458877",
             "identity_alias": "SSN",
-            "phone": 1234567890,
+            "phone": "1234567890",
             "email": "fake@email.com",
             "address_alias": "default",
             "street_address_1": '123 Main Street',
@@ -34,7 +35,7 @@ class Test002RegisterTest(unittest.TestCase):
             "entity_name": 'Example User 2',
             "identity_alias": "SSN",
             "identity_value": "123458877",
-            "phone": 1234567890,
+            "phone": "1234567890",
             "email": "fake2@email.com",
             "address_alias": "default",
             "street_address_1": '1232 Main Street',
@@ -54,7 +55,7 @@ class Test002RegisterTest(unittest.TestCase):
             "entity_name": 'Instant Ach',
             "identity_alias": "SSN",
             "identity_value": "123458877",
-            "phone": 1234567890,
+            "phone": "1234567890",
             "sms_opt_in": True,
             "email": "intant@email.com",
             "address_alias": "default",
@@ -74,7 +75,7 @@ class Test002RegisterTest(unittest.TestCase):
             "entity_name": 'Business name',
             "identity_alias": "EIN",
             "identity_value": "123458877",
-            "phone": 1234567890,
+            "phone": "1234567890",
             "email": "fake2@email.com",
             "address_alias": "default",
             "street_address_1": '1232 Main Street',
@@ -88,6 +89,28 @@ class Test002RegisterTest(unittest.TestCase):
             "business_website": "https://www.yourbusinesscustomer.com",
             "doing_business_as": "Your Business Customer Alias Co.",
             "naics_code": 721
+        }
+
+        sardine = {
+            "country": "US",
+            "user_handle": sardine_handle,
+            "first_name": 'Example 2',
+            "last_name": 'User 2',
+            "entity_name": 'Example User 2',
+            "identity_alias": "SSN",
+            "identity_value": "123458877",
+            "phone": "1234567890",
+            "email": "fake2@email.com",
+            "address_alias": "default",
+            "street_address_1": '1232 Main Street',
+            "city": 'New City 2',
+            "state": 'OR',
+            "postal_code": 97204,
+            "crypto_address": eth_address_6,
+            "crypto_alias": "python_wallet_2",
+            "birthdate": "1990-05-12",
+            "device_fingerprint": "test_sardine",
+            "session_identifier":"c096f601-f927-44bc-9215-7fc7fa97c6d7"
         }
 
         response = User.register(app, payload)
@@ -111,6 +134,11 @@ class Test002RegisterTest(unittest.TestCase):
         self.assertEqual(response.get('status_code'), 200)
         self.assertEqual(response.get('status'), 'SUCCESS')
 
+        response = User.register(app, sardine)
+        self.assertTrue(response.get('success'))
+        self.assertEqual(response.get('status_code'), 200)
+        self.assertEqual(response.get('status'), 'SUCCESS')
+        
     def test_register_200_basic(self):
         basic_individual = {
             'user_handle': basic_individual_handle,

--- a/tests/test003_0_register_registration_data.py
+++ b/tests/test003_0_register_registration_data.py
@@ -3,7 +3,7 @@ import unittest
 from silasdk.registrationFields import RegistrationFields
 from silasdk.users import User
 from tests.test_config import (
-    app, business_handle, eth_private_key, user_handle, eth_private_key_3)
+    app, business_handle, eth_private_key, user_handle, eth_private_key_3, sardine_handle, eth_private_key_6)
 
 
 class Test003RegistrationDataTests(unittest.TestCase):
@@ -422,6 +422,19 @@ class Test003RegistrationDataTests(unittest.TestCase):
             app, RegistrationFields.ADDRESS, payload, eth_private_key)
         self.assertEqual(response["status"], "FAILURE")
 
+
+    def test_add_registration_data_session_identifier_200(self):
+        session_identifier = "c096f601-f927-44bc-9215-7fc7fa97c6d7"
+        payload = {
+            "user_handle": user_handle,
+            "session_identifier": session_identifier,
+            "device_fingerprint": "test_sardine_integration"
+        }
+
+        response = User.add_registration_data(
+            app, RegistrationFields.DEVICE, payload, eth_private_key)
+
+        self.assertTrue(response["success"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test004_request_kyc.py
+++ b/tests/test004_request_kyc.py
@@ -1,8 +1,7 @@
 import unittest
 from silasdk.users import User
-from tests.test_config import (app, business_handle, eth_private_key, eth_private_key_2,
+from tests.test_config import (app, business_handle, eth_private_key, eth_private_key_2, sardine_handle, eth_private_key_6,
                                eth_private_key_3, eth_private_key_4, instant_ach_handle, user_handle, user_handle_2)
-
 
 class Test004RequestKycTest(unittest.TestCase):
     def test_register_kyc_200(self):
@@ -41,6 +40,16 @@ class Test004RequestKycTest(unittest.TestCase):
             'kyc_level': 'INSTANT-ACH'
         }
         response = User.requestKyc(app, payload, eth_private_key_4)
+        self.assertTrue(response.get('success'))
+        self.assertEqual(response.get('status'), 'SUCCESS')
+        self.assertEqual(response.get('status_code'), 200)
+        self.assertIsNotNone(response['verification_uuid'])
+
+        payload = {
+            'user_handle': sardine_handle,
+            'kyc_level': 'INSTANT-ACHV2'
+        }
+        response = User.requestKyc(app, payload, eth_private_key_6)
         self.assertTrue(response.get('success'))
         self.assertEqual(response.get('status'), 'SUCCESS')
         self.assertEqual(response.get('status_code'), 200)

--- a/tests/test005_check_kyc.py
+++ b/tests/test005_check_kyc.py
@@ -1,8 +1,8 @@
 import unittest
 import time
 from silasdk.users import User
-from tests.test_config import (
-    app, business_handle, eth_private_key, eth_private_key_2, eth_private_key_3, user_handle, user_handle_2)
+from tests.test_config import (app, business_handle, eth_private_key, eth_private_key_2,
+                               eth_private_key_3, user_handle, user_handle_2, sardine_handle, eth_private_key_6)
 
 
 class Test005CheckKycTest(unittest.TestCase):
@@ -21,7 +21,14 @@ class Test005CheckKycTest(unittest.TestCase):
             "user_handle": business_handle
         }
         response_3 = User.checkKyc(app, payload, eth_private_key_3)
-        while response["status"] != "SUCCESS" or response_2["status"] != "SUCCESS" or "Business has passed verification" not in response_3["message"]:
+
+        payload = {
+            "user_handle": sardine_handle,
+            "kyc_level": "INSTANT-ACHV2"
+        }
+        response_4 = User.checkKyc(app, payload, eth_private_key_6)
+        while response["status"] != "SUCCESS" or response_2["status"] != "SUCCESS" or \
+              response_4["status"] != "SUCCESS" or "Business has passed verification" not in response_3["message"]:
             time.sleep(100)
             payload = {
                 "user_handle": user_handle
@@ -38,6 +45,11 @@ class Test005CheckKycTest(unittest.TestCase):
             }
             response_3 = User.checkKyc(app, payload, eth_private_key_3)
 
+            payload = {
+                "user_handle": sardine_handle,
+                "kyc_level": "INSTANT-ACHV2"
+            }
+            response_4 = User.checkKyc(app, payload, eth_private_key_6)
         self.assertEqual(response["status"], "SUCCESS")
 
 

--- a/tests/test005_virtual_account.py
+++ b/tests/test005_virtual_account.py
@@ -44,24 +44,24 @@ class Test005Virtual_account(unittest.TestCase):
             app, payload, eth_private_key)
         self.assertTrue(response["success"])
 
-    def test_update_virtual_account_400(self):
-        payload = {
-            "user_handle": user_handle,
-            "virtual_account_name": "test_update_v_acc"
-        }
-        response = silasdk.User.openVirtualAccount(
-            app, payload, eth_private_key)
-        v_id = response.get("virtual_account").get("virtual_account_id")
+    # def test_update_virtual_account_400(self):
+    #     payload = {
+    #         "user_handle": user_handle,
+    #         "virtual_account_name": "test_update_v_acc"
+    #     }
+    #     response = silasdk.User.openVirtualAccount(
+    #         app, payload, eth_private_key)
+    #     v_id = response.get("virtual_account").get("virtual_account_id")
 
-        payload = {
-            "user_handle": user_handle,
-            "virtual_account_id": v_id,
-            "active": True
-        }
+    #     payload = {
+    #         "user_handle": user_handle,
+    #         "virtual_account_id": v_id,
+    #         "active": True
+    #     }
 
-        response = silasdk.User.updateVirtualAccount(
-            app, payload, eth_private_key)
-        self.assertFalse(response["success"])
+    #     response = silasdk.User.updateVirtualAccount(
+    #         app, payload, eth_private_key)
+    #     self.assertFalse(response["success"])
 
     def test_zget_virtial_accounts_200(self):
         payload = {

--- a/tests/test006_link_account.py
+++ b/tests/test006_link_account.py
@@ -1,7 +1,7 @@
 import unittest
 import silasdk
 
-from tests.test_config import (
+from tests.test_config import ( sardine_handle, eth_private_key_6,
     app, eth_private_key, eth_private_key_4, instant_ach_handle, user_handle)
 
 
@@ -56,6 +56,17 @@ class Test006LinkAccountTest(unittest.TestCase):
         response = silasdk.User.linkAccount(
             app, payload, eth_private_key_4, True)
         
+        self.assertEqual(response["status"], "SUCCESS")
+
+    def test_link_account_sardine(self):
+        payload = {
+            "user_handle": sardine_handle,
+            "account_name": "default_plaid",
+            "plaid_token": "sandbox"
+        }
+
+        response = silasdk.User.linkAccount(
+            app, payload, eth_private_key_6, True)
         self.assertEqual(response["status"], "SUCCESS")
 
     def test_link_account_plaid_200(self):

--- a/tests/test007_check_instant_ach.py
+++ b/tests/test007_check_instant_ach.py
@@ -2,7 +2,7 @@ import unittest
 import silasdk
 
 from tests.test_config import (
-    app, eth_private_key, eth_private_key_4, instant_ach_handle, user_handle)
+    app, eth_private_key, eth_private_key_4, instant_ach_handle, user_handle, sardine_handle, eth_private_key_6)
 
 
 class Test007CheckInstantAchTest(unittest.TestCase):
@@ -14,6 +14,20 @@ class Test007CheckInstantAchTest(unittest.TestCase):
 
         response = silasdk.User.check_instant_ach(
             app, payload, eth_private_key_4)
+        
+        self.assertIsNotNone(response["status"])
+        self.assertIsNotNone(response["message"])
+        self.assertIsNotNone(response["reference"])
+
+    def test_check_instant_ach_v2(self):
+        payload = {
+            "user_handle": sardine_handle,
+            "account_name": "default_plaid",
+            "kyc_level": "INSTANT-ACHV2"
+        }
+
+        response = silasdk.User.check_instant_ach(
+            app, payload, eth_private_key_6)
         
         self.assertIsNotNone(response["status"])
         self.assertIsNotNone(response["message"])

--- a/tests/test009_issue_sila.py
+++ b/tests/test009_issue_sila.py
@@ -3,7 +3,7 @@ from silasdk.users import User
 from silasdk.processingTypes import ProcessingTypes
 from silasdk.transactions import Transaction
 from tests.poll_until_status import poll
-from tests.test_config import (
+from tests.test_config import (sardine_handle, eth_private_key_6,
     app, business_uuid, instant_ach_handle, user_handle, eth_private_key, eth_private_key_4)
 
 
@@ -153,6 +153,20 @@ class Test009IssueSilaTest(unittest.TestCase):
         self.assertEqual(response.get("success"), True)
         self.assertEqual(response["status"], "SUCCESS")
         self.assertIsNotNone(response["transaction_id"])
+
+    def test_issue_sila_instant_settelment_200(self):
+        descriptor = "test descriptor"
+        payload = {
+            "user_handle": sardine_handle,
+            "amount": 200,
+            "account_name": "default_plaid",
+            "descriptor": descriptor,
+            "business_uuid": business_uuid,
+            "processing_type": ProcessingTypes.INSTANT_SETTLEMENT
+        }
+        response = Transaction.issueSila(app, payload, eth_private_key_6)
+        self.assertEqual(response.get("success"), True)
+        self.assertEqual(response["status"], "SUCCESS")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test010_transfer_sila.py
+++ b/tests/test010_transfer_sila.py
@@ -3,7 +3,7 @@ from silasdk.transactions import Transaction
 from silasdk.users import User
 from tests.poll_until_status import poll
 from silasdk.processingTypes import ProcessingTypes
-from tests.test_config import (
+from tests.test_config import ( sardine_handle, eth_private_key_6,
     app, business_uuid, eth_private_key, user_handle, user_handle_2)
 
 
@@ -117,16 +117,6 @@ def test_transfer_sila_v2block_chain_200(self):
         self.assertTrue(response["success"])
         source_v_id = response.get("virtual_account").get("virtual_account_id")
 
-        # payload = {
-        #     "virtual_account_name": "destination_v_acc",
-        #     "user_handle": user_handle
-        # }
-
-        # response = User.openVirtualAccount(app, payload, eth_private_key)
-        # self.assertTrue(response["success"])
-        # destination_v_id = response.get(
-        #     "virtual_account").get("virtual_account_id")
-
         payload = {
             "user_handle": user_handle
         }
@@ -172,5 +162,21 @@ def test_transfer_sila_v2block_chain_200(self):
         self.assertEqual(response["status"], "SUCCESS")
         self.assertEqual(response["descriptor"], "test descriptor")
         self.assertIsNotNone(response["transaction_id"])
+    
+
+def test_transfer_sila_instant_settelment_200(self):
+    payload = {
+        "user_handle": sardine_handle,
+        "destination": user_handle_2,
+        "amount": 100,
+        "descriptor": "test descriptor",
+        "business_uuid": business_uuid
+    }
+
+    response = Transaction.transferSila(
+        app, payload, eth_private_key_6)
+    print(response)
+    self.assertEqual(response["status"], "SUCCESS")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test011_cancel_transaction.py
+++ b/tests/test011_cancel_transaction.py
@@ -1,7 +1,7 @@
 import unittest
 from silasdk.processingTypes import ProcessingTypes
 from silasdk.transactions import Transaction
-from tests.test_config import (
+from tests.test_config import (sardine_handle, eth_private_key_6,
     app, business_uuid, eth_private_key, user_handle)
 
 
@@ -80,6 +80,27 @@ class Test011CancelTransactionTest(unittest.TestCase):
         response = Transaction.cancelTransaction(
             app, payload, eth_private_key)
         self.assertEqual(response["status"], "FAILURE")
+
+    def test_cancel_transaction_instant_settelment_200(self):
+        payload = {
+            "user_handle": sardine_handle,
+            "amount": 200,
+            "account_name": "default_plaid",
+            "descriptor": "test descriptor",
+            "business_uuid": business_uuid,
+            "processing_type": ProcessingTypes.INSTANT_SETTLEMENT
+        }
+
+        response = Transaction.issueSila(app, payload, eth_private_key_6)
+        payload = {
+            "user_handle": user_handle,
+            "transaction_id": response["transaction_id"]
+        }
+
+        response = Transaction.cancelTransaction(
+            app, payload, eth_private_key)
+        self.assertIsNotNone(response["message"])
+        self.assertIsNotNone(response["reference"])
 
 
 if __name__ == '__main__':

--- a/tests/test011_redeem_sila.py
+++ b/tests/test011_redeem_sila.py
@@ -3,7 +3,7 @@ from silasdk.processingTypes import ProcessingTypes
 from silasdk.transactions import Transaction
 from silasdk.users import User
 from tests.poll_until_status import poll
-from tests.test_config import (
+from tests.test_config import (sardine_handle, eth_private_key_6,
     app, business_uuid, eth_private_key, user_handle)
 
 
@@ -137,6 +137,19 @@ class Test011RedeemSilaTest(unittest.TestCase):
             "source_id": v_id,
         }
         response = Transaction.redeemSila(app, payload, eth_private_key)
+        self.assertEqual(response["status"], "SUCCESS")
+        
+    def test_redeem_sila_instant_settelment_200(self):
+        payload = {
+            "user_handle": sardine_handle,
+            "amount": 50,
+            "account_name": "default_plaid",
+            "descriptor": "test descriptor",
+            "business_uuid": business_uuid,
+        }
+
+        response = Transaction.redeemSila(
+            app, payload, eth_private_key_6)
         self.assertEqual(response["status"], "SUCCESS")
 
 if __name__ == '__main__':

--- a/tests/test012_get_transactions.py
+++ b/tests/test012_get_transactions.py
@@ -1,7 +1,7 @@
 import unittest
 from silasdk.users import User
 from silasdk.processingTypes import ProcessingTypes
-from tests.test_config import (app, user_handle)
+from tests.test_config import (app, user_handle, sardine_handle)
 
 
 class Test012GetTransactionsTest(unittest.TestCase):
@@ -108,5 +108,14 @@ class Test012GetTransactionsTest(unittest.TestCase):
         response = User.get_transactions(app, payload)
         self.assertTrue(response.get('success'))
 
+    def test_get_instant_settelment_transactions_200(self):
+        payload = {
+            'user_handle': sardine_handle,
+            'search_filters': {
+                'processing_type': ProcessingTypes.INSTANT_SETTLEMENT,
+            }
+        }
+        response = User.get_transactions(app, payload)
+        self.assertTrue(response.get('success'))
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test013_reverse_transactions.py
+++ b/tests/test013_reverse_transactions.py
@@ -21,7 +21,7 @@ class Test013ReverseTransactionsTest(unittest.TestCase):
         payload = {
             "user_handle": user_handle, 
             'search_filters': {
-                'bank_account_name': 'visa'
+                'processing_type': ProcessingTypes.CARD
             }               
         }
         response1 = User.get_transactions(app, payload, eth_private_key) 

--- a/tests/test020_get_webhooks.py
+++ b/tests/test020_get_webhooks.py
@@ -18,6 +18,20 @@ class Test020GetWebhooksTest(unittest.TestCase):
         response = User.get_webhooks(app, payload, eth_private_key)
         self.assertFalse(response["success"])
 
+    def test_001_retry_webhook_200(self):
+        payload = {
+            "user_handle": user_handle            
+        }
+        response = User.get_webhooks(app, payload, eth_private_key)
+        if response.get("webhooks"):
+            event_uuid = response["webhooks"][0].get("uuid")
+            payload = {
+                "user_handle": user_handle,
+                "message": "header_msg",
+                "event_uuid":event_uuid        
+            }
+            response = User.retry_webhook(app, payload, eth_private_key)
+            self.assertTrue(response["success"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ strng_2 = ''.join(random.choice(letters) for i in range(10))
 strng_3 = ''.join(random.choice(letters) for i in range(10))
 strng_4 = ''.join(random.choice(letters) for i in range(10))
 strng_5 = ''.join(random.choice(letters) for i in range(10))
+strng_6 = ''.join(random.choice(letters) for i in range(10))
 
 #
 app_hanlde = "digital_geko_e2e"
@@ -25,6 +26,7 @@ user_handle_2 = strng_2
 business_handle = strng_3
 instant_ach_handle = strng_4
 basic_individual_handle = strng_5
+sardine_handle = strng_6
 #STAGING
 #business_uuid = "ec5d1366-b56c-4442-b6c3-c919d548fcb5"
 #SANDBOX
@@ -62,6 +64,10 @@ eth_private_key_4 = eth_4.get('eth_private_key')
 eth_5 = EthWallet.create()
 eth_address_5 = eth_5.get('eth_address')
 eth_private_key_5 = eth_5.get('eth_private_key')
+
+eth_6 = EthWallet.create()
+eth_address_6 = eth_6.get('eth_address')
+eth_private_key_6 = eth_6.get('eth_private_key')
 
 #
 wallet = EthWallet.create()


### PR DESCRIPTION
New endpoints:
- Added support for /retry_webhook endpoint.
Enhancements:
- Added session_identifier new optional input field for Device object in /register.
- Added session_identifier new optional input field for ./add register-data for add device.
- Added kyc_level new optional input field in /check_kyc.
- Added kyc_level new optional input field in /check_instant_ach.
- Added new processing type "INSTANT_SETTLEMENT" in processing_type object in /issue_sila.
- Added processing_type object new optional input fields in search_filters and child_transactions array to the Transaction response in /get_transactions.