### PR TITLE
release 0.2.41

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,19 @@
+
+v0.2.41
+New endpoints:
+    - Added support for /close_virtual_account endpoint.
+    - Added support for /create_test_virtual_account_ach_transaction endpoint.
+Enhancements:
+    - Added virtual accounts as a type/section and ach_credit_enabled and ach_debit_enabled boolean fields to the response in /get_payment_methods.
+    - Added payment_method_id new optional input field in search_filters in /get_transactions.
+    - Updated uuid to wallet_id input field in internal code in /get_wallets.
+    - Added response_time_ms to the response in API returns.
+    - Added ach_credit_enabled and ach_debit_enabled new optional inputs fields and corresponding response fields in /open_virtual_account.
+    - Added ach_credit_enabled and ach_debit_enabled new optional inputs fields and corresponding response fields in /update_virtual_account.
+    - Added ach_credit_enabled and ach_debit_enabled boolean fields to the response in /get_virtual_accounts.
+    - Added ach_credit_enabled and ach_debit_enabled boolean fields to the response in /get_virtual_account.
+    - Remove identity_type field from /documents request.
+
 v0.2.39
 New endpoints:
     - Added support for /retry_webhook endpoint.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='silasdk',
 
 
-    version='0.2.39',
+    version='0.2.41',
 
     description='Sila Python library for message signing and api wrapper',
 
@@ -33,7 +33,7 @@ setup(
 
     ],
 
-    keywords='Sila v0.2.39 Rest API',
+    keywords='Sila v0.2.41 Rest API',
 
     packages=find_packages(exclude=["tests", "tests.*"]),
 

--- a/silasdk/client.py
+++ b/silasdk/client.py
@@ -142,7 +142,7 @@ class App():
         appsignature = EthWallet.signMessage(msg, self.app_private_key)
         header = {
             "authsignature": appsignature,
-            "User-Agent": 'SilaSDK-python/0.2.39'
+            "User-Agent": 'SilaSDK-python/0.2.41'
         }
         if content_type is not None and content_type == 'multipart/form-data':
             pass

--- a/silasdk/endpoints.py
+++ b/silasdk/endpoints.py
@@ -50,5 +50,7 @@ endPoints = {
     "getVirtualAccount": "/get_virtual_account",
     "getVirtualAccounts": "/get_virtual_accounts",
     "updateVirtualAccount": "/update_virtual_account",
-    "getPaymentMethods":"/get_payment_methods",
+    "getPaymentMethods": "/get_payment_methods",
+    "closeVirtualAccount": "/close_virtual_account",
+    "testVirtualAaccountAchTransaction": "/create_test_virtual_account_ach_transaction",
 }

--- a/silasdk/schema.py
+++ b/silasdk/schema.py
@@ -164,7 +164,8 @@ Schema = [
             "sort_ascending": None,
             "blockchain_network": None,
             "blockchain_address": None,
-            "nickname": None
+            "nickname": None,
+            "wallet_id":None
         }
     }},
     {"get_accounts_msg": {
@@ -329,6 +330,7 @@ Schema = [
             "transaction_types": [],
             "bank_account_name":None,
             "processing_type": None,
+            "payment_method_id":None,
         }
     }},
     {'cancel_transaction_msg': {
@@ -417,7 +419,6 @@ Schema = [
         "hash": None,
         "mime_type": None,
         "document_type": None,
-        "identity_type": None,
         "description": None
     }},
     {"list_documents_msg": {
@@ -646,7 +647,9 @@ Schema = [
                 "crypto": "ETH", 
                 "reference": None
             },
-            "virtual_account_name": None
+            "virtual_account_name": None,
+            "ach_credit_enabled": None,
+            "ach_debit_enabled": None
         }
     },
     {
@@ -689,7 +692,9 @@ Schema = [
             },
             "virtual_account_id": None,
             "virtual_account_name": None,
-            "active": None
+            "active": None,
+            "ach_credit_enabled": None,
+            "ach_debit_enabled": None
         }
     },
     {
@@ -702,5 +707,40 @@ Schema = [
                 "reference": None,
             }
         }
-    }
+    },
+    {
+        "close_virtual_account_msg": {
+            "header": {
+                "created": None, 
+                "auth_handle": None, 
+                "user_handle": None, 
+                "app_handle": None,
+                "version": "0.2", 
+                "crypto": "ETH", 
+                "reference": None
+            },
+            "virtual_account_id": None,
+            "account_number": None,
+        }
+    },
+    {
+        "create_test_virtual_account_ach_transaction_msg": {
+            "header": {
+                "created": None, 
+                "auth_handle": None, 
+                "user_handle": None, 
+                "app_handle": None,
+                "version": "0.2", 
+                "crypto": "ETH", 
+                "reference": None
+            },
+            "amount": None,
+            "virtual_account_number": None,
+            "tran_code": None,
+            "effective_date": None,
+            "entity_name": None,
+            "ced": None,
+            "ach_name": None
+        }
+    },
 ]

--- a/silasdk/users.py
+++ b/silasdk/users.py
@@ -131,10 +131,10 @@ class User():
         return response
 
     def openVirtualAccount(self, payload, user_private_key):
-        """get the accounts of users registered with sila
-            The user will be checked if they have been kyced, along with app
+        """open virtual account for a user
         Args:
             user_hanlde: users handle registered with app
+            payload : includes virtual_account_name, ach_credit_enabled, ach_debit_enabled
             user_private_key: user private key asscoicated with crypto address
         Returns:
             dict: response body (a confirmation message)
@@ -146,10 +146,10 @@ class User():
         return response
         
     def getVirtualAccount(self, payload, user_private_key):
-        """get the accounts of users registered with sila
-            The user will be checked if they have been kyced, along with app
+        """get the virtual account of users registered with sila
         Args:
             user_hanlde: users handle registered with app
+            payload: virtual_account_id
             user_private_key: user private key asscoicated with crypto address
         Returns:
             dict: response body (a confirmation message)
@@ -161,8 +161,7 @@ class User():
         return response
 
     def getVirtualAccounts(self, payload, user_private_key):
-        """get the accounts of users registered with sila
-            The user will be checked if they have been kyced, along with app
+        """get virtual accounts of users registered with sila
         Args:
             user_hanlde: users handle registered with app
             user_private_key: user private key asscoicated with crypto address
@@ -176,10 +175,10 @@ class User():
         return response
 
     def updateVirtualAccount(self, payload, user_private_key):
-        """get the accounts of users registered with sila
-            The user will be checked if they have been kyced, along with app
+        """update virtual account of users registered with sila
         Args:
             user_hanlde: users handle registered with app
+            payload: virtual_account_id, virtual_account_name, active, ach_debit_enabled, ach_credit_enabled
             user_private_key: user private key asscoicated with crypto address
         Returns:
             dict: response body (a confirmation message)
@@ -190,8 +189,38 @@ class User():
             self, path, msg_type, payload, user_private_key)
         return response
 
+    def closeVirtualAccount(self, payload, user_private_key):
+        """close virtual account of users registered with sila
+        Args:
+            user_hanlde: users handle registered with app
+            payload: virtual_account_id, account_number
+            user_private_key: user private key asscoicated with crypto address
+        Returns:
+            dict: response body (a confirmation message)
+        """
+        path = endPoints["closeVirtualAccount"]
+        msg_type = "close_virtual_account_msg"
+        response = message.postRequest(
+            self, path, msg_type, payload, user_private_key)
+        return response
+
+    def testVirtualAaccountAchTransaction(self, payload, user_private_key):
+        """test transaction for virtual account(works only with sandbox)
+        Args:
+            user_hanlde: users handle registered with app
+            payload: amount, virtual_account_number, effective_date, tran_code, entity_name, ced, ach_name
+            user_private_key: user private key asscoicated with crypto address
+        Returns:
+            dict: response body (a confirmation message)
+        """
+        path = endPoints["testVirtualAaccountAchTransaction"]
+        msg_type = "create_test_virtual_account_ach_transaction_msg"
+        response = message.postRequest(
+            self, path, msg_type, payload, user_private_key)
+        return response
+
     def getPaymentMethods(self, payload, user_private_key):
-        """get the accounts of users registered with sila
+        """get payment methods of users registered with sila
             The user will be checked if they have been kyced, along with app
         Args:
             user_hanlde: users handle registered with app

--- a/test_suite.py
+++ b/test_suite.py
@@ -47,6 +47,7 @@ from tests.test017_update_wallet import Test017UpdateWalletTest
 from tests.test018_delete_wallet import Test018DeleteWalletTest
 from tests.test019_sila_balance import Test019GetSilaBalanceTest
 from tests.test020_get_webhooks import Test020GetWebhooksTest
+from tests.test021_get_payment_methods import Test021GetPaymentMethods
 
 
 def create_suite(classes):
@@ -109,7 +110,8 @@ def run_unit_tests():
             Test017UpdateWalletTest,
             Test018DeleteWalletTest,
             Test019GetSilaBalanceTest,
-            Test020GetWebhooksTest
+            Test020GetWebhooksTest,
+            Test021GetPaymentMethods
         ]
         runner.run(create_suite(classes))
     cov.stop()

--- a/tests/test001_get_business_roles.py
+++ b/tests/test001_get_business_roles.py
@@ -11,6 +11,7 @@ class Test001GetBusinessRolesTest(unittest.TestCase):
         self.assertIsNotNone(response["business_roles"][0]["name"])
         self.assertIsNotNone(response["business_roles"][0]["label"])
         self.assertIsNotNone(response["reference"])
+        self.assertIsNotNone(response["response_time_ms"])  
 
 
 if __name__ == "__main__":

--- a/tests/test001_get_institutions.py
+++ b/tests/test001_get_institutions.py
@@ -10,6 +10,7 @@ class Test001GetInstitutionsTest(unittest.TestCase):
         response = silasdk.User.get_institutions(app, payload)
         self.assertTrue(response["success"])
         self.assertIsNotNone(response["reference"])
+        self.assertIsNotNone(response["response_time_ms"])  
 
 
 if __name__ == "__main__":

--- a/tests/test002_register.py
+++ b/tests/test002_register.py
@@ -110,7 +110,7 @@ class Test002RegisterTest(unittest.TestCase):
             "crypto_alias": "python_wallet_2",
             "birthdate": "1990-05-12",
             "device_fingerprint": "test_sardine",
-            "session_identifier":"c096f601-f927-44bc-9215-7fc7fa97c6d7"
+            "session_identifier":"ppppp-aaaa-dddd-99ce-c45944174e0c"
         }
 
         response = User.register(app, payload)

--- a/tests/test003_0_register_registration_data.py
+++ b/tests/test003_0_register_registration_data.py
@@ -424,7 +424,7 @@ class Test003RegistrationDataTests(unittest.TestCase):
 
 
     def test_add_registration_data_session_identifier_200(self):
-        session_identifier = "c096f601-f927-44bc-9215-7fc7fa97c6d7"
+        session_identifier = "ppppp-aaaa-dddd-99ce-c45944174e0c"
         payload = {
             "user_handle": user_handle,
             "session_identifier": session_identifier,

--- a/tests/test005_virtual_account.py
+++ b/tests/test005_virtual_account.py
@@ -10,12 +10,16 @@ class Test005Virtual_account(unittest.TestCase):
     def test_open_virtual_account_200(self):
         payload = {
             "virtual_account_name": "test_v_acc",
-            "user_handle": user_handle
+            "user_handle": user_handle,
+            "ach_credit_enabled": True,
+            "ach_debit_enabled": False
         }
         response = silasdk.User.openVirtualAccount(
             app, payload, eth_private_key)
         self.assertTrue(response["success"])
-
+        self.assertIsNotNone(response.get('virtual_account').get('ach_debit_enabled'))
+        self.assertIsNotNone(response.get('virtual_account').get('ach_credit_enabled'))
+        
     def test_open_virtual_account_400(self):
         payload = {
             "virtual_account_name": "test_v_acc"
@@ -27,7 +31,9 @@ class Test005Virtual_account(unittest.TestCase):
     def test_update_virtual_account_200(self):
         payload = {
             "user_handle": user_handle,
-            "virtual_account_name": "test_update_v_acc"
+            "virtual_account_name": "test_update_v_acc",
+            "ach_credit_enabled": True,
+            "ach_debit_enabled": False
         }
         response = silasdk.User.openVirtualAccount(
             app, payload, eth_private_key)
@@ -37,31 +43,16 @@ class Test005Virtual_account(unittest.TestCase):
             "user_handle": user_handle,
             "virtual_account_id": v_id,
             "virtual_account_name": "updates_test_v_acc",
-            "active": False
+            "active": False,
+            "ach_debit_enabled": True,
+            "ach_credit_enabled": False,
         }
 
         response = silasdk.User.updateVirtualAccount(
             app, payload, eth_private_key)
         self.assertTrue(response["success"])
-
-    # def test_update_virtual_account_400(self):
-    #     payload = {
-    #         "user_handle": user_handle,
-    #         "virtual_account_name": "test_update_v_acc"
-    #     }
-    #     response = silasdk.User.openVirtualAccount(
-    #         app, payload, eth_private_key)
-    #     v_id = response.get("virtual_account").get("virtual_account_id")
-
-    #     payload = {
-    #         "user_handle": user_handle,
-    #         "virtual_account_id": v_id,
-    #         "active": True
-    #     }
-
-    #     response = silasdk.User.updateVirtualAccount(
-    #         app, payload, eth_private_key)
-    #     self.assertFalse(response["success"])
+        self.assertTrue(response.get('virtual_account').get('ach_debit_enabled'))
+        self.assertFalse(response.get('virtual_account').get('ach_credit_enabled'))
 
     def test_zget_virtial_accounts_200(self):
         payload = {
@@ -71,6 +62,8 @@ class Test005Virtual_account(unittest.TestCase):
         response = silasdk.User.getVirtualAccounts(
             app, payload, eth_private_key)
         self.assertTrue(response["success"])
+        self.assertIsNotNone(response.get('virtual_accounts')[0].get('ach_debit_enabled'))
+        self.assertIsNotNone(response.get('virtual_accounts')[0].get('ach_credit_enabled'))
 
     def test_zget_virtial_account_200(self):
         payload = {
@@ -87,6 +80,50 @@ class Test005Virtual_account(unittest.TestCase):
         }
 
         response = silasdk.User.getVirtualAccount(
+            app, payload, eth_private_key)
+        self.assertTrue(response["success"])
+        self.assertIsNotNone(response.get('virtual_account').get('ach_debit_enabled'))
+        self.assertIsNotNone(response.get('virtual_account').get('ach_credit_enabled'))
+        
+
+    def test_close_virtual_account_200(self):
+        payload = {
+            "user_handle": user_handle,
+            "virtual_account_name": "test_close_v_acc"
+        }
+        response = silasdk.User.openVirtualAccount(
+            app, payload, eth_private_key)
+        v_id = response.get("virtual_account").get("virtual_account_id")
+        v_no = response.get("virtual_account").get("account_number")
+
+        payload = {
+            "user_handle": user_handle,
+            "virtual_account_id": v_id,
+            "account_number": v_no
+        }
+
+        response = silasdk.User.closeVirtualAccount(
+            app, payload, eth_private_key)
+        self.assertTrue(response["success"])
+
+    def test_create_virtual_account_ach_transaction_200(self):
+        payload = {
+            "user_handle": user_handle,
+            "virtual_account_name": "test_close_v_acc"
+        }
+        response = silasdk.User.openVirtualAccount(
+            app, payload, eth_private_key)
+        v_no = response.get("virtual_account").get("account_number")
+
+        payload = {
+            "user_handle": user_handle,
+            "amount": 50,
+            "virtual_account_number": v_no,
+            "tran_code": 22,
+            "entity_name": "Test transfer",
+        }
+
+        response = silasdk.User.testVirtualAaccountAchTransaction(
             app, payload, eth_private_key)
         self.assertTrue(response["success"])
 

--- a/tests/test009_issue_sila.py
+++ b/tests/test009_issue_sila.py
@@ -119,6 +119,7 @@ class Test009IssueSilaTest(unittest.TestCase):
             self.assertEqual(response["error_code"], "INSTANT_ACH_NO_MATCH_SCORE")      
 
     def test_issue_sila_vaccount_200(self):
+        card_id=None
         payload = {
             "virtual_account_name": "test_v_acc",
             "user_handle": user_handle

--- a/tests/test010_transfer_sila.py
+++ b/tests/test010_transfer_sila.py
@@ -175,7 +175,6 @@ def test_transfer_sila_instant_settelment_200(self):
 
     response = Transaction.transferSila(
         app, payload, eth_private_key_6)
-    print(response)
     self.assertEqual(response["status"], "SUCCESS")
 
 if __name__ == '__main__':

--- a/tests/test012_get_transactions.py
+++ b/tests/test012_get_transactions.py
@@ -89,6 +89,17 @@ class Test012GetTransactionsTest(unittest.TestCase):
         self.assertEqual(response.get('transactions')[
                          0].get('transaction_type'), 'issue')
 
+        payment_method_id = response.get("transactions")[0].get("transaction_id")
+        payload = {
+            'user_handle': user_handle,
+            'search_filters': {
+                'payment_method_id': payment_method_id
+            }
+        }
+        response = User.get_transactions(app, payload)
+
+        self.assertTrue(response.get('success'))
+
     def test_get_transactions_400(self):
         payload = {
             "user_handle": ""

--- a/tests/test015_get_wallets.py
+++ b/tests/test015_get_wallets.py
@@ -19,6 +19,16 @@ class Test015GetWalletsTest(unittest.TestCase):
         response = silasdk.Wallet.getWallets(app, payload, eth_private_key)
         self.assertTrue(response["success"])
         self.assertIsNotNone(response["reference"])
+        wallet_id = response.get("wallets")[0].get("wallet_id")
+        payload = {
+            "user_handle": user_handle,
+            "search_filters": {
+                "wallet_id": wallet_id
+            }
+        }
+        response = silasdk.Wallet.getWallets(app, payload, eth_private_key)
+        self.assertTrue(response["success"])
+        self.assertIsNotNone(response["reference"])
 
     def test_get_wallets_400(self):
         payload = {

--- a/tests/test021_get_payment_methods.py
+++ b/tests/test021_get_payment_methods.py
@@ -1,0 +1,23 @@
+import unittest
+import silasdk
+
+from tests.test_config import *
+
+
+class Test021GetPaymentMethods(unittest.TestCase):
+    def test_get_payment_methods_200(self):
+        payload = {
+            "user_handle": user_handle
+        }
+        response = silasdk.User.getPaymentMethods(
+            app, payload, eth_private_key)
+        self.assertTrue(response["success"])
+        for method in response["payment_methods"]:
+            if method["payment_method_type"] == "virtual_account":
+                self.assertEqual(method["payment_method_type"], "virtual_account")
+                self.assertIsNotNone(method["ach_credit_enabled"])
+                self.assertIsNotNone(method["ach_debit_enabled"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
New endpoints:
    - Added support for /close_virtual_account endpoint.
    - Added support for /create_test_virtual_account_ach_transaction endpoint.
Enhancements:
    - Added virtual accounts as a type/section and ach_credit_enabled and ach_debit_enabled boolean fields to the response in /get_payment_methods.
    - Added payment_method_id new optional input field in search_filters in /get_transactions.
    - Updated uuid to wallet_id input field in internal code in /get_wallets.
    - Added response_time_ms to the response in API returns.
    - Added ach_credit_enabled and ach_debit_enabled new optional inputs fields and corresponding response fields in /open_virtual_account.
    - Added ach_credit_enabled and ach_debit_enabled new optional inputs fields and corresponding response fields in /update_virtual_account.
    - Added ach_credit_enabled and ach_debit_enabled boolean fields to the response in /get_virtual_accounts.
    - Added ach_credit_enabled and ach_debit_enabled boolean fields to the response in /get_virtual_account.
    - Remove identity_type field from /documents request.
